### PR TITLE
Fixed require in all files

### DIFF
--- a/lib/relp.rb
+++ b/lib/relp.rb
@@ -1,4 +1,4 @@
-require_relative 'relp/server'
+require 'relp/server'
 
 module Relp
 	server = Relp::RelpServer.new('0.0.0.0', 2000, 'syslog', nil )

--- a/lib/relp/relp_protocol.rb
+++ b/lib/relp/relp_protocol.rb
@@ -1,4 +1,4 @@
-require_relative 'exceptions'
+require 'exceptions'
 require 'socket'
 module Relp
 

--- a/lib/relp/server.rb
+++ b/lib/relp/server.rb
@@ -1,4 +1,4 @@
-require_relative 'relp_protocol'
+require 'relp_protocol'
 require 'logger'
 require 'thread'
 

--- a/relp.gemspec
+++ b/relp.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require_relative 'relp/version'
+require 'relp/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "relp"
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["dhlavacd@redhat.com"]
 
   spec.summary       = "Ruby implementation of RELP (Reliable Event Logging Protocol) protocol."
-  spec.description   = "Ruby implementation of RELP (Reliable Event Logging Protocol) protocol."
+  spec.description   = "If you want to receive or send message via RELP protocol you can use this gem"
   spec.homepage      = "https://github.com/dhlavac/Relp"
   spec.license       = "MIT"
 


### PR DESCRIPTION
After building gem works require instead of require_relative. Before running gem, run 

> build relp.gemspec

  and  

> gem install ./relp-0.0.1.gem