### PR TITLE
temporarily reverting frame checking 

### DIFF
--- a/lib/relp/relp_protocol.rb
+++ b/lib/relp/relp_protocol.rb
@@ -34,7 +34,7 @@ module Relp
         frame = Hash.new
         if match = socket_content.match(/(^[0-9]+) ([\S]*) (\d+)([\s\S]*)/)
           frame[:txnr], frame[:command], frame[:data_length], frame[:message] = match.captures
-          check_message_length(frame)
+          # check_message_length(frame) - currently unstable, needs some more work
           frame[:message].lstrip! #message could be empty
         else
           raise Relp::FrameReadException.new('Problem with reading RELP frame')

--- a/lib/relp/version.rb
+++ b/lib/relp/version.rb
@@ -1,3 +1,3 @@
 module Relp
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
as it causes errors in higher messages throughput and when clients closes connection
It needs more work  before it can be re-enabled 