### PR TITLE
Rewrite of plugin to fully implement protocol

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,10 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+Rake::TestTask.new do |test|
+  test.libs << "test"
+  test.pattern = 'test/**/*_test.rb'
+  test.verbose = true
 end
 
-desc "Run Tests"
 task :default => :test

--- a/lib/relp/exceptions.rb
+++ b/lib/relp/exceptions.rb
@@ -5,15 +5,9 @@ module Relp
   class ConnectionClosed < RelpProtocolError
   end
 
-  class ConnectionRefused < RelpProtocolError
+  class FrameParseException < RelpProtocolError
   end
 
-  class FrameReadException < RelpProtocolError
-  end
-
-  class InvalidCommand < RelpProtocolError
-  end
-
-  class MissingData < RelpProtocolError
+  class InvalidOffer < RelpProtocolError
   end
 end

--- a/lib/relp/relp_session.rb
+++ b/lib/relp/relp_session.rb
@@ -1,0 +1,107 @@
+require 'relp/relp_protocol'
+require 'logger'
+require 'thread'
+
+module Relp
+  class RelpSession < RelpProtocol
+    def initialize(socket, callback, logger = nil)
+      @logger = logger
+      @logger = Logger.new(STDOUT) if logger.nil?
+      @socket = socket
+      @remote_ip = socket.peeraddr[3]
+      @callback = callback
+
+      begin
+        connection_setup()
+        process()
+        close()
+      rescue Relp::ConnectionClosed
+        @logger.warn "Relp unexpected Connection closed"
+      rescue Relp::FrameParseException => err
+        # We can't respond to a bad frame because we do not know its :txnr
+        @logger.warn 'Relp frame parse error', :exception => err
+      rescue Relp::RelpProtocolError => err
+        @logger.warn 'Relp protocol error', :exception => err
+      rescue OpenSSL::SSL::SSLError => ssl_error
+        @logger.warn "Relp SSL Error", :exception => ssl_error
+      end
+    end
+
+    private
+    def read_socket()
+      begin
+        # Assume that the client is well behaved and only sends one message before
+        # waiting for a reply.  A streaming client would require parsing of the stream
+        # in order as the end of frame marker \n can also be part of the frame.
+        data = @socket.readpartial(4096)
+        data.chomp!
+        @logger.debug "Relp #{@remote_ip} read: #{data.dump}"
+        return data
+      rescue Errno::EPIPE,Errno::ECONNRESET,EOFError
+        @logger.debug "Relp #{@remote_ip} read: connection reset"
+        raise Relp::ConnectionClosed
+      rescue StandardException => err
+        @logger.debug "Relp #{@remote_ip} read: ", :exception => err
+        retry
+      end
+    end
+
+    def write_socket(data)
+      begin
+        @logger.debug "Relp #{@remote_ip} write: #{data.dump}"
+        @socket.puts(data)
+      rescue Errno::EPIPE,Errno::ECONNRESET,EOFError
+        @logger.debug "Relp #{@remote_ip} write: connection reset"
+        raise Relp::ConnectionClosed
+      rescue StandardException => err
+        @logger.debug "Relp #{@remote_ip} write: ", :exception => err
+        retry
+      end
+    end
+
+    def connection_setup()
+      begin
+        socket_content = read_socket()
+        frame = frame_parse(socket_content)
+        if frame[:command] != 'open'
+          raise Relp::RelpProtocolError.new("Relp #{@remote_ip} expected open, got #{frame[:command].dump}")
+        end
+        validate_offer(frame[:message])
+        write_socket(ack_offer_frame(frame))
+        @logger.info "Relp #{@remote_ip} connection negotiated"
+      rescue Relp::InvalidOffer => err
+        @logger.error "Relp #{@remote_ip} invalid connection offer", :exception => err
+        write_socket(nack_frame(frame, err.message))
+        retry
+      end
+    end
+
+    def process()
+      while Thread.current.alive? do
+        socket_content = read_socket()
+        frame = frame_parse(socket_content)
+        case frame[:command]
+        when 'syslog'
+          @logger.info "Relp #{@remote_ip} message: '#{frame[:message].dump}'"
+          @callback.call(frame[:message], @remote_ip)
+          write_socket(ack_frame(frame))
+        when 'close'
+          write_socket(ack_frame(frame))
+          return
+        else
+          @logger.warn "Relp #{@remote_ip} unknown command #{frame[:command].dump}"
+          write_socket(nack_frame(frame, 'Unknown command'))
+        end
+      end
+    end
+
+    def close()
+      # socket might already be closed
+      begin
+        write_socket('0 close 0')
+      rescue StandardException
+      end
+    end
+
+  end
+end

--- a/lib/relp/server.rb
+++ b/lib/relp/server.rb
@@ -1,22 +1,22 @@
-require 'relp/relp_protocol'
+require 'relp/relp_session'
 require 'logger'
 require 'thread'
-require "openssl"
+require 'openssl'
 
 module Relp
-  class RelpServer < RelpProtocol
+  class RelpServer
     def initialize(port, callback, host = '0.0.0.0' , tls_context = nil, logger = nil)
       @logger = logger
       @logger = Logger.new(STDOUT) if logger.nil?
       @socket_list = Array.new
       @callback = callback
-      @required_command = 'syslog'
 
       begin
         @server = TCPServer.new host, port
         if tls_context
           @logger.info "Starting #{self.class} with SSL enabled on %s:%i" % @server.local_address.ip_unpack
           @server = OpenSSL::SSL::SSLServer.new(@server, tls_context)
+          @server.start_immediately = true
         else
           @logger.info "Starting #{self.class} on %s:%i" % @server.local_address.ip_unpack
         end
@@ -27,137 +27,43 @@ module Relp
     end
 
     def run
-      loop do
-        client_socket = @server.accept
-        Thread.start(client_socket) do |client_socket|
-          begin
-            @socket_list.push client_socket
-            remote_ip = client_socket.peeraddr[3]
-            @logger.info "New client connection coming from ip #{remote_ip}"
-            @logger.debug "New client started with object id=#{client_socket.object_id}"
-            connection_setup(client_socket)
-            while Thread.current.alive? do
-              ready = IO.select([client_socket], nil, nil, 10)
-              if ready
-                frame = communication_processing(client_socket)
-                return_message(frame[:message], (@callback))
-                ack_frame(client_socket,frame[:txnr])
-              end
+      begin
+        loop do
+          client_socket = @server.accept
+          Thread.start(client_socket) do |client_socket|
+            begin
+              @socket_list.push client_socket
+              remote_ip = client_socket.peeraddr[3]
+              @logger.info "New client connection coming from ip #{remote_ip}"
+              RelpSession.new(client_socket, @callback, @logger)
+            ensure
+              @socket_list.delete client_socket
+              @logger.info "Connection from ip #{remote_ip} closed"
             end
-          rescue Relp::ConnectionClosed
-            @logger.info "Connection closed"
-          rescue Relp::RelpProtocolError => err
-            @logger.warn 'Relp error: ' + err.class.to_s + ' ' + err.message
-          rescue OpenSSL::SSL::SSLError => ssl_error
-            @logger.error "SSL Error", :exception => ssl_error
-          rescue Exception => e
-            @logger.debug e
-          ensure
-            server_close_message(client_socket) rescue nil
-            @logger.debug "Closing client socket=#{client_socket.object_id}"
-            @logger.info "Client from ip #{remote_ip} closed"
           end
         end
-      end
-    rescue Errno::EINVAL
-      # Swallowing exception here because it results even from properly closed socket
-      @logger.info "Socket close."
-    end
-
-    def return_message(message, callback)
-      list_of_messages = message.split(/\n+/)
-      list_of_messages.each do |msg|
-        remove = msg.split(": ").first + ": "
-        msg.slice! remove
-        callback.call(msg)
-      end
-    end
-
-    def ack_frame(socket, txnr)
-      frame = {:txnr => txnr,
-               :command => 'rsp',
-               :message => "6 200 OK\n"
-      }
-      frame_write(socket, frame)
-    end
-
-    def server_close_message(socket)
-      Hash.new frame = {:txnr => 0,
-               :command => 'close',
-               :message => '0'
-      }
-      begin
-        frame_write(socket,frame)
-        @logger.debug 'Server close message send'
-        socket.close
-        @socket_list.delete socket
-      rescue Relp::ConnectionClosed
+      rescue OpenSSL::SSL::SSLError => ssl_error
+        # Certificate issues are thrown on accept
+        @logger.error "SSL Connection Error", :exception => ssl_error
+        retry
+      rescue Errno::EINVAL
+        # When @server.shutdown is called
+      rescue StandardError => err
+        @logger.error 'unexpected error', :exception => err
+        @logger.error_backtrace
       end
     end
 
     def server_shutdown
       @socket_list.each do |client_socket|
-        if client_socket != nil
-	        server_close_message(client_socket)
-	      end
+        client_socket.close() if client_socket != nil
       end
-      @logger.info 'Server shutdown'
+      @logger.info 'Relp server shutdown'
       @server.shutdown
       @server = nil
     end
 
     private
-    def communication_processing(socket)
-      @logger.debug 'Communication processing'
-      frame = frame_read(socket)
-      if frame[:command] == 'syslog'
-        return frame
-      elsif frame[:command] == 'close'
-        response_frame = create_frame(frame[:txnr], "rsp", "0")
-        frame_write(socket,response_frame)
-        @logger.info 'Client send close message'
-        server_close_message(socket)
-        raise Relp::ConnectionClosed
-      else
-        server_close_message(socket)
-        raise Relp::RelpProtocolError, 'Wrong relp command'
-      end
-    end
 
-    def connection_setup(socket)
-      @logger.debug 'Connection setup'
-      begin
-        read_ready = IO.select([socket], nil, nil, 10)
-        if read_ready
-          frame = frame_read(socket)
-          @logger.debug 'Frame read complete, processing..'
-          if frame[:command] == 'open'
-            @logger.debug 'Client command open'
-            message_informations = extract_message_information(frame[:message])
-            if message_informations[:relp_version].empty?
-              @logger.warn 'Missing RELP version specification'
-              server_close_message(socket)
-              raise Relp::RelpProtocolError
-            elsif @required_command != message_informations[:commands]
-              @logger.warn 'Missing required commands - syslog'
-              Hash.new response_frame = create_frame(frame[:txnr], 'rsp', '20 500 Missing required command ' + @required_command)
-              frame_write(socket, response_frame)
-              server_close_message(socket)
-              raise Relp::InvalidCommand, 'Missing required command'
-            else
-              Hash.new response_frame = create_frame(frame[:txnr], 'rsp', '93 200 OK' + "\n" + 'relp_version=' +@@relp_version + "\n" + 'relp_software=' + @@relp_software + "\n" + 'commands=' + @required_command + "\n")
-              @logger.debug 'Sending response to client'
-              frame_write(socket, response_frame)
-            end
-          else
-            server_close_message(socket)
-            raise Relp::InvalidCommand, frame[:command] + ' expecting open command'
-          end
-        end
-      rescue Relp::RelpProtocolError
-        @logger.debug 'Timed out (no frame to read)'
-        server_close_message(socket)
-      end
-    end
   end
 end

--- a/lib/relp/server.rb
+++ b/lib/relp/server.rb
@@ -5,14 +5,14 @@ require 'openssl'
 
 module Relp
   class RelpServer
-    def initialize(port, callback, host = '0.0.0.0' , tls_context = nil, logger = nil)
+    def initialize(port, callback, host: '0.0.0.0' , tls_context: nil, logger: nil)
       @logger = logger
       @logger = Logger.new(STDOUT) if logger.nil?
       @socket_list = Array.new
       @callback = callback
 
       begin
-        @server = TCPServer.new host, port
+        @server = TCPServer.new(host, port)
         if tls_context
           @logger.info "Starting #{self.class} with SSL enabled on %s:%i" % @server.local_address.ip_unpack
           @server = OpenSSL::SSL::SSLServer.new(@server, tls_context)

--- a/lib/relp/version.rb
+++ b/lib/relp/version.rb
@@ -1,3 +1,3 @@
 module Relp
-  VERSION = "0.2.1"
+  VERSION = "1.0.0".freeze
 end

--- a/relp.gemspec
+++ b/relp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/relp.gemspec
+++ b/relp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
 end

--- a/test/RELP_test.rb
+++ b/test/RELP_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class RELPTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Relp::VERSION
-  end
-
-
-end

--- a/test/client.rb
+++ b/test/client.rb
@@ -1,0 +1,25 @@
+require 'socket'
+
+class Client
+  attr_reader :socket
+
+  def initialize(port, logger)
+    @logger = logger
+    @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+    @socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+    @socket.connect Socket.pack_sockaddr_in(port, '127.0.0.1')
+  end
+
+  def send_data(data)
+    @logger.debug("Client sending #{data.dump}")
+    @socket.puts data
+  end
+
+  def recv_data
+    @logger.debug("Client waiting for message")
+    data = @socket.readpartial(4096)
+    @logger.debug("Client received #{data.dump}")
+    data.chomp
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,3 @@
 require 'relp'
+require 'client'
 require 'minitest/autorun'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,2 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'relp'
-
 require 'minitest/autorun'

--- a/test/unit/relp_server_test.rb
+++ b/test/unit/relp_server_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+require 'logger'
+
+CONNECT_STRING = "relp_version=0\nrelp_software=librelp,1.4.0,http://librelp.adiscon.com\ncommands=syslog"
+CONNECT_RESPONSE = "200 OK\nrelp_version=0\nrelp_software=ruby-relp,1.0.0,https://github.com/ViaQ/Relp\ncommands=syslog"
+
+class TestRelpSession < MiniTest::Test
+  def setup
+    @logger = Logger.new STDERR
+    @logger.level = Logger::DEBUG
+    @callback = Minitest::Mock.new
+    @server = Relp::RelpServer.new(1234, @callback, logger: @logger)
+    @server_thread = Thread.new { @server.run }
+    @client = Client.new 1234, @logger
+  end
+
+  def teardown
+    @callback.verify
+    @client.send_data('0 close 0')
+    @client.socket.close
+    @server.server_shutdown
+    @server_thread.join
+  end
+
+  def connect
+    @msg_number = 1
+    @client.send_data("#{@msg_number} open #{CONNECT_STRING.length} #{CONNECT_STRING}")
+    data = @client.recv_data
+    assert_equal("#{@msg_number} rsp #{CONNECT_RESPONSE.length} #{CONNECT_RESPONSE}", data)
+  end
+
+  def syslog(msg)
+    @msg_number += 1
+    @client.send_data("#{@msg_number} syslog #{msg.length} #{msg}")
+    resp = @client.recv_data
+    assert_equal("#{@msg_number} rsp 6 200 OK", resp)
+  end
+
+  def test_connect
+    connect
+  end
+
+  def test_send
+    connect
+    @callback.expect(:call, nil, [ "test", "127.0.0.1" ])
+    syslog("test")
+  end
+
+  def test_multi_send
+    connect
+    @callback.expect(:call, nil, [ "test", "127.0.0.1" ])
+    @callback.expect(:call, nil, [ "foo", "127.0.0.1" ])
+    @callback.expect(:call, nil, [ "bar", "127.0.0.1" ])
+    syslog("test")
+    syslog("foo")
+    syslog("bar")
+  end
+
+end

--- a/test/unit/relp_test.rb
+++ b/test/unit/relp_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class RELPTest < Minitest::Test
+  def test_that_it_has_a_version_number
+    refute_nil ::Relp::VERSION
+  end
+
+
+end


### PR DESCRIPTION
This is a significant rewrite of the plugin to address several issues I encountered with the previous version.

1) Errors during the SSL handshake would cause the server to crash.
2) Every ~30s connections would be dropped due to SSL queuing issues.
3) Messages were being munged before being sent up to the callback.
4) The plugin was not providing information on the peer, making it unclear where messages are coming from when talking to multiple clients.
5) The implementation now does a proper length check on messages, addressing https://github.com/ViaQ/Relp/issues/16

I bumped the version number to 1.0.0 due to the change in both callback parameters and the change in what data is returned (i.e. it does not trim trailing new lines).

Unfortunately there are no unit tests and it has only been extensively tested against the rsyslog librelp implementation. 

Assuming this looks good I will make a separate pull request for fluent-plugin-relp to use this version of the relp plugin.